### PR TITLE
fix: add Cross.toml to install libssl-dev for Linux cross-compilation

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,7 @@
+[build.env]
+passthrough = ["CARGO_TERM_COLOR"]
+
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update && apt-get install -y libssl-dev pkg-config"
+]


### PR DESCRIPTION
## Summary
Fixes nightly Linux build failure where `openssl-sys` can't find libssl-dev in the cross Docker image.

## Root cause
```
Could not find openssl via pkg-config
The system library \`openssl\` required by crate \`openssl-sys\` was not found
```

openssl-sys is pulled transitively via:
- `reqwest` (default-tls → native-tls → openssl-sys) used by pforge-runtime
- `pmcp` websocket (tokio-tungstenite → native-tls)

The `cross` container doesn't have libssl-dev preinstalled.

## Fix
Add `Cross.toml` with pre-build step to install libssl-dev + pkg-config.

## Alternative (deferred)
Switching reqwest to rustls-tls + patching pmcp to avoid native-tls would eliminate the native dep entirely. Larger PR, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)